### PR TITLE
feat: add Vintage and Premodern archetype definitions

### DIFF
--- a/data/archetypes/premodern.yaml
+++ b/data/archetypes/premodern.yaml
@@ -1,0 +1,131 @@
+format: Premodern
+date: "2026-03-15"
+archetypes:
+  - name: Mono-Blue Stiflenought
+    signatureCards:
+      - name: "Vision Charm"
+        minCopies: 1
+      - name: "Phyrexian Dreadnought"
+        minCopies: 1
+      - name: "Stifle"
+        minCopies: 1
+  - name: Mono-Red Sligh
+    signatureCards:
+      - name: "Lightning Bolt"
+        minCopies: 1
+      - name: "Fireblast"
+        minCopies: 1
+      - name: "Jackal Pup"
+        minCopies: 1
+  - name: Gruul Goblins
+    signatureCards:
+      - name: "Goblin Lackey"
+        minCopies: 1
+      - name: "Goblin Warchief"
+        minCopies: 1
+      - name: "Goblin Piledriver"
+        minCopies: 1
+  - name: Elves
+    signatureCards:
+      - name: "Wirewood Symbiote"
+        minCopies: 1
+      - name: "Llanowar Elves"
+        minCopies: 1
+      - name: "Fyndhorn Elves"
+        minCopies: 1
+  - name: Azorius Standstill
+    signatureCards:
+      - name: "Counterspell"
+        minCopies: 1
+      - name: "Swords to Plowshares"
+        minCopies: 1
+      - name: "Mana Leak"
+        minCopies: 1
+  - name: Selesnya Enchantress
+    signatureCards:
+      - name: "Enchantress's Presence"
+        minCopies: 1
+      - name: "Argothian Enchantress"
+        minCopies: 1
+      - name: "Mirri's Guile"
+        minCopies: 1
+  - name: Tireless Tribe
+    signatureCards:
+      - name: "Wild Mongrel"
+        minCopies: 1
+      - name: "Swords to Plowshares"
+        minCopies: 1
+      - name: "Basking Rootwalla"
+        minCopies: 1
+  - name: Azorius Replenish
+    signatureCards:
+      - name: "Replenish"
+        minCopies: 1
+      - name: "Opalescence"
+        minCopies: 1
+      - name: "Parallax Wave"
+        minCopies: 1
+  - name: Naya Terragedon
+    signatureCards:
+      - name: "Swords to Plowshares"
+        minCopies: 1
+      - name: "Mox Diamond"
+        minCopies: 1
+      - name: "Terravore"
+        minCopies: 1
+  - name: Mono-Black Midrange
+    signatureCards:
+      - name: "Dark Ritual"
+        minCopies: 1
+      - name: "Duress"
+        minCopies: 1
+      - name: "Hypnotic Specter"
+        minCopies: 1
+  - name: Orzhov Control
+    signatureCards:
+      - name: "Swords to Plowshares"
+        minCopies: 1
+      - name: "Vindicate"
+        minCopies: 1
+      - name: "Gerrard's Verdict"
+        minCopies: 1
+  - name: The Rock
+    signatureCards:
+      - name: "Cabal Therapy"
+        minCopies: 1
+      - name: "Pernicious Deed"
+        minCopies: 1
+      - name: "Wall of Blossoms"
+        minCopies: 1
+  - name: Azorius
+    signatureCards:
+      - name: "Swords to Plowshares"
+        minCopies: 1
+      - name: "Mother of Runes"
+        minCopies: 1
+      - name: "Whipcorder"
+        minCopies: 1
+  - name: Gro-A-Tog
+    signatureCards:
+      - name: "Gush"
+        minCopies: 1
+      - name: "Portent"
+        minCopies: 1
+      - name: "Opt"
+        minCopies: 1
+  - name: Gruul Sligh
+    signatureCards:
+      - name: "Lightning Bolt"
+        minCopies: 1
+      - name: "Call of the Herd"
+        minCopies: 1
+      - name: "Grim Lavamancer"
+        minCopies: 1
+  - name: Bant
+    signatureCards:
+      - name: "Impulse"
+        minCopies: 1
+      - name: "Chain of Vapor"
+        minCopies: 1
+      - name: "Gush"
+        minCopies: 1

--- a/data/archetypes/vintage.yaml
+++ b/data/archetypes/vintage.yaml
@@ -1,0 +1,99 @@
+format: Vintage
+date: "2026-03-15"
+archetypes:
+  - name: Lurrus PO
+    signatureCards:
+      - name: "Lurrus of the Dream-Den"
+        minCopies: 1
+      - name: "Stock Up"
+        minCopies: 1
+      - name: "Thundertrap Trainer"
+        minCopies: 1
+  - name: Raker Shops
+    signatureCards:
+      - name: "Grim Monolith"
+        minCopies: 1
+      - name: "The One Ring"
+        minCopies: 1
+      - name: "Sensei's Divining Top"
+        minCopies: 1
+  - name: Mono-White Initiative
+    signatureCards:
+      - name: "White Plume Adventurer"
+        minCopies: 1
+      - name: "Chrome Mox"
+        minCopies: 1
+      - name: "Seasoned Dungeoneer"
+        minCopies: 1
+  - name: Esper Lurrus Control
+    signatureCards:
+      - name: "Lurrus of the Dream-Den"
+        minCopies: 1
+      - name: "Orcish Bowmasters"
+        minCopies: 1
+      - name: "Psychic Frog"
+        minCopies: 1
+  - name: Jewel Shops
+    signatureCards:
+      - name: "Coveted Jewel"
+        minCopies: 1
+      - name: "Transmute Artifact"
+        minCopies: 1
+      - name: "The One Ring"
+        minCopies: 1
+  - name: Sphere Shops
+    signatureCards:
+      - name: "Sphere of Resistance"
+        minCopies: 1
+      - name: "Patchwork Automaton"
+        minCopies: 1
+      - name: "Null Rod"
+        minCopies: 1
+  - name: Dredge
+    signatureCards:
+      - name: "Bazaar of Baghdad"
+        minCopies: 1
+      - name: "Force of Negation"
+        minCopies: 1
+      - name: "Grief"
+        minCopies: 1
+  - name: Dimir Lurrus Control
+    signatureCards:
+      - name: "Lurrus of the Dream-Den"
+        minCopies: 1
+      - name: "Orcish Bowmasters"
+        minCopies: 1
+      - name: "Psychic Frog"
+        minCopies: 1
+  - name: Lurrus Breach
+    signatureCards:
+      - name: "Lurrus of the Dream-Den"
+        minCopies: 1
+      - name: "Stock Up"
+        minCopies: 1
+      - name: "Mana Drain"
+        minCopies: 1
+  - name: Oath of Druids
+    signatureCards:
+      - name: "Oath of Druids"
+        minCopies: 1
+      - name: "Atraxa, Grand Unifier"
+        minCopies: 1
+      - name: "Ponder"
+        minCopies: 1
+  - name: Blue Tempo
+    signatureCards:
+      - name: "Psychic Frog"
+        minCopies: 1
+      - name: "Collector Ouphe"
+        minCopies: 1
+      - name: "Murktide Regent"
+        minCopies: 1
+  - name: Doomsday
+    signatureCards:
+      - name: "Doomsday"
+        minCopies: 1
+      - name: "Lurrus of the Dream-Den"
+        minCopies: 1
+      - name: "Psychic Frog"
+        minCopies: 1


### PR DESCRIPTION
## Summary
- Adds `data/archetypes/vintage.yaml` with 12 archetypes above 2% metagame share
- Adds `data/archetypes/premodern.yaml` with 16 archetypes above 2% metagame share
- Signature cards sourced from MTGGoldfish metagame pages

## Test plan
- [ ] Verify archetypes load correctly in the app for Vintage and Premodern formats
- [ ] Spot-check a few archetype card names for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)