### PR TITLE
feat: add anyOf group support to signature card matching

### DIFF
--- a/scripts/lib/html-parser.ts
+++ b/scripts/lib/html-parser.ts
@@ -135,9 +135,11 @@ export function parseDecklistRecords(details: MeleeDecklistDetails): ParsedDeckl
 function parseDate(raw: string): string {
 	if (!raw) return "";
 	// Input format: "4/26/2024 4:00:00 PM" (US format)
-	const d = new Date(raw);
-	if (Number.isNaN(d.getTime())) return raw;
-	return d.toISOString().split("T")[0]; // "2024-04-26"
+	// Extract date parts directly to avoid timezone shifts from Date → toISOString()
+	const match = raw.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})/);
+	if (!match) return raw;
+	const [, month, day, year] = match;
+	return `${year}-${month.padStart(2, "0")}-${day.padStart(2, "0")}`;
 }
 
 function parseFormats(registration: string): string[] {

--- a/src/lib/algorithms/archetype-classifier.ts
+++ b/src/lib/algorithms/archetype-classifier.ts
@@ -1,8 +1,10 @@
 import { parse as parseYaml } from "yaml";
-import type {
-	ArchetypeDefinition,
-	ArchetypeYaml,
-	ParsedArchetypeConfig,
+import {
+	type ArchetypeDefinition,
+	type ArchetypeYaml,
+	isAnyOfGroup,
+	type ParsedArchetypeConfig,
+	type SignatureCard,
 } from "../types/archetype";
 import type { CardEntry, DecklistInfo } from "../types/decklist";
 import { getCommanderShortName, getFrontFace } from "../utils/card-normalizer";
@@ -28,6 +30,21 @@ export function parseArchetypeYaml(yamlContent: string): ParsedArchetypeConfig {
 		archetypes: data.archetypes ?? [],
 		nameEqualsCommander: data.nameEqualsCommander ?? false,
 	};
+}
+
+function matchesSingleCard(
+	sig: SignatureCard,
+	cardQuantities: Map<string, number>,
+	commanderNames: Set<string>,
+): boolean {
+	if (sig.usedAsCommander) {
+		return commanderNames.has(sig.name);
+	}
+	const qty = cardQuantities.get(sig.name) ?? 0;
+	if (sig.exactCopies !== undefined) {
+		return qty === sig.exactCopies;
+	}
+	return qty >= (sig.minCopies ?? 1);
 }
 
 /**
@@ -59,15 +76,13 @@ export function classifyBySignatureCards(
 	let bestMatchCount = 0;
 
 	for (const archetype of archetypeDefs) {
-		const allMatch = archetype.signatureCards.every((sig) => {
-			if (sig.usedAsCommander) {
-				return commanderNames.has(sig.name);
+		const allMatch = archetype.signatureCards.every((entry) => {
+			if (isAnyOfGroup(entry)) {
+				return entry.anyOf.some((sig) =>
+					matchesSingleCard(sig, cardQuantities, commanderNames),
+				);
 			}
-			const qty = cardQuantities.get(sig.name) ?? 0;
-			if (sig.exactCopies !== undefined) {
-				return qty === sig.exactCopies;
-			}
-			return qty >= (sig.minCopies ?? 1);
+			return matchesSingleCard(entry, cardQuantities, commanderNames);
 		});
 
 		if (allMatch && archetype.signatureCards.length > bestMatchCount) {

--- a/src/lib/stores/tournaments.ts
+++ b/src/lib/stores/tournaments.ts
@@ -6,7 +6,7 @@ import { derived, get, writable } from "svelte/store";
 import type { ClassificationResult } from "../algorithms/archetype-classifier";
 import { classifyAll, classifyAllPooled } from "../algorithms/archetype-classifier";
 import { loadIndexes, loadTournaments } from "../data/loader";
-import type { ArchetypeDefinition } from "../types/archetype";
+import { type ArchetypeDefinition, isAnyOfGroup } from "../types/archetype";
 import type { DecklistInfo } from "../types/decklist";
 import type { ArchetypeStats } from "../types/metagame";
 import type {
@@ -159,7 +159,12 @@ export const archetypeCardMap = derived(
 		const map = new Map<string, string>(
 			$defs
 				.filter((d) => d.signatureCards.length > 0)
-				.map((d) => [d.name, d.signatureCards[0].name]),
+				.map((d) => {
+					const first = d.signatureCards[0];
+					const name = isAnyOfGroup(first) ? first.anyOf[0]?.name : first.name;
+					return [d.name, name] as [string, string];
+				})
+				.filter((pair): pair is [string, string] => !!pair[1]),
 		);
 		// Add commander-classified archetypes (representativeCard → full card name for Scryfall)
 		for (const results of $resultsMap.values()) {

--- a/src/lib/types/archetype.ts
+++ b/src/lib/types/archetype.ts
@@ -5,9 +5,19 @@ export interface SignatureCard {
 	usedAsCommander?: boolean;
 }
 
+export interface AnyOfGroup {
+	anyOf: SignatureCard[];
+}
+
+export type SignatureEntry = SignatureCard | AnyOfGroup;
+
+export function isAnyOfGroup(entry: SignatureEntry): entry is AnyOfGroup {
+	return "anyOf" in entry;
+}
+
 export interface ArchetypeDefinition {
 	name: string;
-	signatureCards: SignatureCard[];
+	signatureCards: SignatureEntry[];
 	strictMode?: boolean;
 }
 

--- a/src/lib/types/archetype.ts
+++ b/src/lib/types/archetype.ts
@@ -12,7 +12,7 @@ export interface AnyOfGroup {
 export type SignatureEntry = SignatureCard | AnyOfGroup;
 
 export function isAnyOfGroup(entry: SignatureEntry): entry is AnyOfGroup {
-	return "anyOf" in entry;
+	return "anyOf" in entry && Array.isArray((entry as AnyOfGroup).anyOf);
 }
 
 export interface ArchetypeDefinition {

--- a/src/lib/utils/yaml-validator.ts
+++ b/src/lib/utils/yaml-validator.ts
@@ -7,6 +7,31 @@ export interface ValidationResult {
 	warnings: string[];
 }
 
+function validateSignatureCard(
+	card: Record<string, unknown>,
+	prefix: string,
+	errors: string[],
+	warnings: string[],
+): void {
+	if (!card || typeof card !== "object") {
+		errors.push(`${prefix}: must be an object`);
+		return;
+	}
+
+	if (!card.name || typeof card.name !== "string") {
+		errors.push(`${prefix}: missing or invalid "name"`);
+	}
+
+	const hasMin = card.minCopies !== undefined;
+	const hasExact = card.exactCopies !== undefined;
+
+	if (!hasMin && !hasExact) {
+		warnings.push(
+			`${prefix} (${card.name ?? "?"}): no minCopies or exactCopies (defaults to minCopies: 1)`,
+		);
+	}
+}
+
 /**
  * Validate archetype YAML content with structured error/warning output.
  */
@@ -89,26 +114,29 @@ export function validateArchetypeYaml(yamlContent: string): ValidationResult {
 		}
 
 		for (let j = 0; j < arch.signatureCards.length; j++) {
-			const card = arch.signatureCards[j] as Record<string, unknown>;
-			const cardPrefix = `${prefix}.signatureCards[${j}]`;
+			const entry = arch.signatureCards[j] as Record<string, unknown>;
+			const entryPrefix = `${prefix}.signatureCards[${j}]`;
 
-			if (!card || typeof card !== "object") {
-				errors.push(`${cardPrefix}: must be an object`);
+			if (!entry || typeof entry !== "object") {
+				errors.push(`${entryPrefix}: must be an object`);
 				continue;
 			}
 
-			if (!card.name || typeof card.name !== "string") {
-				errors.push(`${cardPrefix}: missing or invalid "name"`);
+			if (Array.isArray(entry.anyOf)) {
+				// Validate anyOf group
+				if (entry.anyOf.length === 0) {
+					errors.push(`${entryPrefix}.anyOf: must not be empty`);
+					continue;
+				}
+				for (let k = 0; k < entry.anyOf.length; k++) {
+					const card = entry.anyOf[k] as Record<string, unknown>;
+					const cardPrefix = `${entryPrefix}.anyOf[${k}]`;
+					validateSignatureCard(card, cardPrefix, errors, warnings);
+				}
+				continue;
 			}
 
-			const hasMin = card.minCopies !== undefined;
-			const hasExact = card.exactCopies !== undefined;
-
-			if (!hasMin && !hasExact) {
-				warnings.push(
-					`${cardPrefix} (${card.name ?? "?"}): no minCopies or exactCopies (defaults to minCopies: 1)`,
-				);
-			}
+			validateSignatureCard(entry, entryPrefix, errors, warnings);
 		}
 	}
 

--- a/src/routes/archetype-cleaner/attribution/+page.svelte
+++ b/src/routes/archetype-cleaner/attribution/+page.svelte
@@ -13,6 +13,7 @@
 	import CardTooltip from '$lib/components/CardTooltip.svelte';
 	import type { DecklistInfo } from '$lib/types/decklist';
 	import type { ClassificationResult } from '$lib/algorithms/archetype-classifier';
+	import { isAnyOfGroup } from '$lib/types/archetype';
 	import { computeCardComposition } from '$lib/utils/card-composition';
 
 	const classifiedName = $derived(page.url.searchParams.get('classified') ?? '');
@@ -142,21 +143,40 @@
 						</tr>
 					</thead>
 					<tbody>
-						{#each archetypeDef.signatureCards as card}
-							<tr>
-								<td>
-									<CardTooltip cardName={card.name}>
-										<span class="card-name">{card.name}</span>
-									</CardTooltip>
-								</td>
-								<td class="num">
-									{#if card.exactCopies !== undefined}
-										= {card.exactCopies}
-									{:else}
-										≥ {card.minCopies ?? 1}
-									{/if}
-								</td>
-							</tr>
+						{#each archetypeDef.signatureCards as entry}
+							{#if isAnyOfGroup(entry)}
+								{#each entry.anyOf as card, i}
+									<tr>
+										<td>
+											<CardTooltip cardName={card.name}>
+												<span class="card-name">{i === 0 ? '' : 'or '}{ card.name}</span>
+											</CardTooltip>
+										</td>
+										<td class="num">
+											{#if card.exactCopies !== undefined}
+												= {card.exactCopies}
+											{:else}
+												≥ {card.minCopies ?? 1}
+											{/if}
+										</td>
+									</tr>
+								{/each}
+							{:else}
+								<tr>
+									<td>
+										<CardTooltip cardName={entry.name}>
+											<span class="card-name">{entry.name}</span>
+										</CardTooltip>
+									</td>
+									<td class="num">
+										{#if entry.exactCopies !== undefined}
+											= {entry.exactCopies}
+										{:else}
+											≥ {entry.minCopies ?? 1}
+										{/if}
+									</td>
+								</tr>
+							{/if}
 						{/each}
 					</tbody>
 				</table>

--- a/tests/unit/archetype-classifier.test.ts
+++ b/tests/unit/archetype-classifier.test.ts
@@ -328,6 +328,123 @@ describe("classifyBySignatureCards", () => {
 		expect(result).toBe("Aclazotz Deck");
 	});
 
+	// --- anyOf tests ---
+
+	it("anyOf matches when at least one card in the group is present", () => {
+		const defs: ArchetypeDefinition[] = [
+			{
+				name: "Mardu Energy",
+				signatureCards: [
+					{ name: "Ocelot Pride", minCopies: 3 },
+					{
+						anyOf: [
+							{ name: "Orcish Bowmasters", minCopies: 1 },
+							{ name: "Scrubland", minCopies: 1 },
+							{ name: "Badlands", minCopies: 1 },
+						],
+					},
+				],
+			},
+		];
+		// Has Scrubland but not Bowmasters
+		const mainboard = cards(["Ocelot Pride", 4], ["Scrubland", 2], ["Plains", 10]);
+		expect(classifyBySignatureCards(mainboard, null, defs)).toBe("Mardu Energy");
+	});
+
+	it("anyOf rejects when no card in the group matches", () => {
+		const defs: ArchetypeDefinition[] = [
+			{
+				name: "Mardu Energy",
+				signatureCards: [
+					{ name: "Ocelot Pride", minCopies: 3 },
+					{
+						anyOf: [
+							{ name: "Orcish Bowmasters", minCopies: 1 },
+							{ name: "Scrubland", minCopies: 1 },
+						],
+					},
+				],
+			},
+		];
+		// Has neither Bowmasters nor Scrubland
+		const mainboard = cards(["Ocelot Pride", 4], ["Plains", 16]);
+		expect(classifyBySignatureCards(mainboard, null, defs)).toBeNull();
+	});
+
+	it("anyOf respects minCopies within the group", () => {
+		const defs: ArchetypeDefinition[] = [
+			{
+				name: "Black Splash",
+				signatureCards: [
+					{
+						anyOf: [
+							{ name: "Thoughtseize", minCopies: 3 },
+							{ name: "Cabal Therapy", minCopies: 3 },
+						],
+					},
+				],
+			},
+		];
+		// Has Thoughtseize but below minCopies
+		const mainboard = cards(["Thoughtseize", 2], ["Land", 18]);
+		expect(classifyBySignatureCards(mainboard, null, defs)).toBeNull();
+
+		// Has enough Cabal Therapy
+		const mainboard2 = cards(["Cabal Therapy", 3], ["Land", 17]);
+		expect(classifyBySignatureCards(mainboard2, null, defs)).toBe("Black Splash");
+	});
+
+	it("anyOf counts as one signature entry for tiebreaking", () => {
+		const defs: ArchetypeDefinition[] = [
+			{
+				name: "Simple",
+				signatureCards: [
+					{ name: "Card A", minCopies: 1 },
+					{ name: "Card B", minCopies: 1 },
+					{ name: "Card C", minCopies: 1 },
+				],
+			},
+			{
+				name: "With AnyOf",
+				signatureCards: [
+					{ name: "Card A", minCopies: 1 },
+					{ anyOf: [{ name: "Card B", minCopies: 1 }] },
+				],
+			},
+		];
+		const mainboard = cards(["Card A", 4], ["Card B", 4], ["Card C", 4]);
+		// Simple has 3 entries, With AnyOf has 2 — Simple wins
+		expect(classifyBySignatureCards(mainboard, null, defs)).toBe("Simple");
+	});
+
+	it("anyOf works in YAML parsing", () => {
+		const yaml = `
+format: Legacy
+date: "2026-03-19"
+archetypes:
+  - name: Mardu Pride
+    signatureCards:
+      - name: Ocelot Pride
+        minCopies: 3
+      - anyOf:
+          - name: Orcish Bowmasters
+            minCopies: 1
+          - name: Scrubland
+            minCopies: 1
+          - name: Badlands
+            minCopies: 1
+`;
+		const result = parseArchetypeYaml(yaml);
+		expect(result.archetypes).toHaveLength(1);
+		expect(result.archetypes[0].signatureCards).toHaveLength(2);
+		const anyOfEntry = result.archetypes[0].signatureCards[1];
+		expect("anyOf" in anyOfEntry).toBe(true);
+		if ("anyOf" in anyOfEntry) {
+			expect(anyOfEntry.anyOf).toHaveLength(3);
+			expect(anyOfEntry.anyOf[0].name).toBe("Orcish Bowmasters");
+		}
+	});
+
 	it("mixed usedAsCommander and minCopies signature cards", () => {
 		const defs: ArchetypeDefinition[] = [
 			{

--- a/tests/unit/yaml-validator.test.ts
+++ b/tests/unit/yaml-validator.test.ts
@@ -120,4 +120,68 @@ archetypes:
 		const result = validateArchetypeYaml("just a string");
 		expect(result.ok).toBe(false);
 	});
+
+	// --- anyOf tests ---
+
+	it("validates anyOf groups in signature cards", () => {
+		const yaml = `
+archetypes:
+  - name: Mardu Pride
+    signatureCards:
+      - name: Ocelot Pride
+        minCopies: 3
+      - anyOf:
+          - name: Orcish Bowmasters
+            minCopies: 1
+          - name: Scrubland
+            minCopies: 1
+`;
+		const result = validateArchetypeYaml(yaml);
+		expect(result.ok).toBe(true);
+		expect(result.errors).toHaveLength(0);
+	});
+
+	it("returns error for empty anyOf group", () => {
+		const yaml = `
+archetypes:
+  - name: Bad
+    signatureCards:
+      - anyOf: []
+`;
+		const result = validateArchetypeYaml(yaml);
+		expect(result.ok).toBe(false);
+		expect(result.errors.some((e) => e.includes("anyOf: must not be empty"))).toBe(
+			true,
+		);
+	});
+
+	it("validates cards inside anyOf groups", () => {
+		const yaml = `
+archetypes:
+  - name: Bad
+    signatureCards:
+      - anyOf:
+          - minCopies: 1
+`;
+		const result = validateArchetypeYaml(yaml);
+		expect(result.ok).toBe(false);
+		expect(result.errors.some((e) => e.includes('missing or invalid "name"'))).toBe(
+			true,
+		);
+	});
+
+	it("warns on anyOf cards missing minCopies/exactCopies", () => {
+		const yaml = `
+archetypes:
+  - name: Test
+    signatureCards:
+      - anyOf:
+          - name: Some Card
+`;
+		const result = validateArchetypeYaml(yaml);
+		expect(result.ok).toBe(true);
+		expect(result.warnings.some((w) => w.includes("no minCopies or exactCopies"))).toBe(
+			true,
+		);
+	});
 });


### PR DESCRIPTION
## Summary
- Adds `anyOf` groups to the signature card schema, enabling OR logic in archetype definitions
- A signature entry can now be either a single card requirement or an `anyOf` group where at least one card must match
- Each `anyOf` group counts as 1 entry for the "most signature matches" tiebreak
- Updates the YAML validator to recognize and validate `anyOf` groups

## YAML syntax
```yaml
- name: Reanimator
  signatureCards:
    - name: Archon of Cruelty
      minCopies: 3
    - anyOf:
        - name: Reanimate
          minCopies: 1
        - name: Animate Dead
          minCopies: 1
        - name: Exhume
          minCopies: 1
```

## Changes
- `src/lib/types/archetype.ts` — new `AnyOfGroup` interface, `SignatureEntry` union type, `isAnyOfGroup` type guard
- `src/lib/algorithms/archetype-classifier.ts` — extracted `matchesSingleCard` helper, updated matching loop to handle `anyOf`
- `src/lib/utils/yaml-validator.ts` — validates `anyOf` entries and their nested cards, rejects empty groups
- `tests/unit/archetype-classifier.test.ts` — 5 new tests covering match/reject/minCopies/tiebreak/YAML parsing
- `tests/unit/yaml-validator.test.ts` — 4 new tests for anyOf validation
- `scripts/lib/html-parser.ts` — fixes timezone shift in date parsing (cherry-picked from #15)

## Test plan
- [x] 546/546 tests pass
- [x] anyOf matches when at least one card present
- [x] anyOf rejects when no cards match
- [x] minCopies/exactCopies respected within anyOf groups
- [x] anyOf counts as one entry for tiebreaking
- [x] YAML parsing round-trips correctly
- [x] Validator accepts valid anyOf, rejects empty anyOf, validates nested cards